### PR TITLE
feat: 스크롤 기능 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -52,7 +52,6 @@ export async function getDateFestivals(date) {
     const year = date.getFullYear();
     const month = date.getMonth();
     const day = date.getDate();
-    console.log(year, month, day);
     const res = await axios.get(`${API_URL}/festivals/date`, {
       params: { year, month, day },
     });

--- a/frontend/src/components/Calendar.css
+++ b/frontend/src/components/Calendar.css
@@ -1,9 +1,8 @@
 .calendar-wrapper {
-  /* Calendar wrapper styles */
+  margin: auto;
 }
 
 .calendar-table {
-  width: 100%;
   table-layout: fixed;
   border-collapse: separate;
   border-spacing: 1px;
@@ -33,13 +32,13 @@
 }
 
 .calendar-cell-empty {
-  height: 90px;
+  height: 60px;
   background-color: #f8f9fa;
   border: 1px solid #e9ecef;
 }
 
-.calendar-cell {
-  height: 90px;
+.calendar-table .calendar-cell {
+  height: 60px;
   vertical-align: top;
   padding: 0;
   cursor: pointer;
@@ -64,17 +63,18 @@
 }
 
 .calendar-cell-content {
-  padding: 8px;
   height: 100%;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
 }
 
 .calendar-date {
-  font-size: 32px;
+  font-size: 20px;
   line-height: 1;
   text-align: center;
-  margin-bottom: 4px;
 }
 
 .calendar-date.today {
@@ -97,11 +97,6 @@
   color: #495057;
 }
 
-.calendar-festival-count {
-  margin-top: auto;
-  font-size: 18px;
-  color: #28a745;
-  text-align: center;
-  font-weight: 700;
-  padding: 2px;
+.festival-count {
+  font-size: 20px;
 }

--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -45,12 +45,9 @@ export default function Calendar(props) {
                       date.toDateString() === today.toDateString();
                     const isSelected =
                       date.toDateString() === selectedDate.toDateString();
-                    console.log(
-                      date.toDateString(),
-                      selectedDate.toDateString()
-                    );
+
                     let dateBox = (
-                      <td className="calendar-cell-empty">
+                      <td key={weekIndex * 7 + dayIndex} className="calendar-cell-empty">
                         <div className="p-2">
                           {/* 이번 달이 아닌 날짜는 숫자를 표시하지 않음 */}
                         </div>

--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Table } from "react-bootstrap";
+import Badge from "react-bootstrap/Badge";
 import { getMonthFestivals } from "../api/api";
 import "./Calendar.css";
 
@@ -80,11 +81,13 @@ export default function Calendar(props) {
                           onClick={() => props.onChangeDay(date.getDate())}
                         >
                           <div className="calendar-cell-content">
-                            <div className={dateClasses}>{date.getDate()}</div>
+                            <div className={`${dateClasses} mb-1`}>
+                              {date.getDate()}
+                            </div>
                             {monthInfo[date.getDate()] > 0 && (
-                              <div className="calendar-festival-count">
-                                {monthInfo[date.getDate()]}개
-                              </div>
+                              <Badge pill className="festival-count">
+                                {monthInfo[date.getDate()]}
+                              </Badge>
                             )}
                           </div>
                         </td>

--- a/frontend/src/components/FestivalCardList.jsx
+++ b/frontend/src/components/FestivalCardList.jsx
@@ -1,6 +1,7 @@
 import Card from "react-bootstrap/Card";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import { Link } from "react-router-dom";
+import { forwardRef } from "react";
 
 function FestivalCard(props) {
   let festival = props.festival;
@@ -21,13 +22,37 @@ function FestivalCard(props) {
 
   return (
     <>
-      <li className="festival_card_item" style={{ display: 'inline-block', margin: '1rem' }}>
-        <Card as={Link} to={`/festivals/${festival._id}`} style={{ width: '20rem', height: '20rem', border: 'none', textDecorationLine: 'none' }}>
-          <Card.Img src={festival.thumbnail_url} style={{ overflowClipMargin: 'content-box', overflow: 'hidden', objectFit: 'cover', height: '15rem' }} />
+      <li
+        className="festival_card_item"
+        style={{ display: "inline-block", margin: "1rem" }}
+      >
+        <Card
+          as={Link}
+          to={`/festivals/${festival._id}`}
+          style={{
+            width: "20rem",
+            height: "20rem",
+            border: "none",
+            textDecorationLine: "none",
+          }}
+        >
+          <Card.Img
+            src={festival.thumbnail_url}
+            style={{
+              overflowClipMargin: "content-box",
+              overflow: "hidden",
+              objectFit: "cover",
+              height: "15rem",
+            }}
+          />
           <Card.Body className="festival_card_body">
-            <Card.Title style={{ fontWeight: 'bold' }}>{festival.name}</Card.Title>
-            <Card.Text style={{ fontSize: '0.9rem', color: '#555' }}>
-              {formatDate(festival.start_date)} ~ {formatDate(festival.end_date)}<br />
+            <Card.Title style={{ fontWeight: "bold" }}>
+              {festival.name}
+            </Card.Title>
+            <Card.Text style={{ fontSize: "0.9rem", color: "#555" }}>
+              {formatDate(festival.start_date)} ~{" "}
+              {formatDate(festival.end_date)}
+              <br />
               {festival.region}
             </Card.Text>
           </Card.Body>
@@ -37,24 +62,26 @@ function FestivalCard(props) {
   );
 }
 
-function FestivalCardList(props) {
+const FestivalCardList = (props, ref) => {
   let filteredFestivals = props.festivals;
 
   return (
-    <div className="festival_card_list_container">
+    <div className="festival_card_list_container" ref={ref}>
       {/* <Breadcrumb className="festival_visual_list_order_btn">
         <Breadcrumb.Item active as="span" style={{ textDecorationLine: 'none'}}>축제일순</Breadcrumb.Item>
         <Breadcrumb.Item as="span" style={{ textDecorationLine: 'none'}}>거리순</Breadcrumb.Item>
         <Breadcrumb.Item as="span" style={{ textDecorationLine: 'none'}}>인기순</Breadcrumb.Item>
       </Breadcrumb> */}
-      <ul className="festival_card_list" style={{ paddingLeft: '0', width: 'fit-content' }}>
+      <ul
+        className="festival_card_list"
+        style={{ paddingLeft: "0", width: "fit-content" }}
+      >
         {filteredFestivals.map((festival) => (
           <FestivalCard key={festival._id} festival={festival} />
         ))}
       </ul>
-
     </div>
   );
-}
+};
 
-export default FestivalCardList;
+export default forwardRef(FestivalCardList);

--- a/frontend/src/components/FestivalVisualList.jsx
+++ b/frontend/src/components/FestivalVisualList.jsx
@@ -1,6 +1,5 @@
 import Card from "react-bootstrap/Card";
 import { Link } from "react-router-dom";
-import { forwardRef } from "react";
 
 function FestivalVisual(props) {
   let festival = props;

--- a/frontend/src/components/FestivalVisualList.jsx
+++ b/frontend/src/components/FestivalVisualList.jsx
@@ -1,17 +1,18 @@
 import Card from "react-bootstrap/Card";
 import { Link } from "react-router-dom";
+import { forwardRef } from "react";
 
 function FestivalVisual(props) {
   let festival = props;
 
   const formatDate = (date_str) => {
-    if (!date_str) return '';
+    if (!date_str) return "";
     try {
       const d = new Date(date_str);
       if (Number.isNaN(d.getTime())) return String(date_str).slice(0, 10);
       const yyyy = d.getFullYear();
-      const mm = String(d.getMonth() + 1).padStart(2, '0');
-      const dd = String(d.getDate()).padStart(2, '0');
+      const mm = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
       return `${yyyy}-${mm}-${dd}`;
     } catch {
       return String(date_str).slice(0, 10);
@@ -20,13 +21,55 @@ function FestivalVisual(props) {
 
   return (
     <>
-      <li className="festival_visual_item" style={{ display: 'inline-block', margin: '1rem' }}>
-        <Card as={Link} to={`/festivals/${festival._id}`} style={{ width: '15rem', height: '30rem', border: 'none', position: 'relative', textDecorationLine: 'none' }}>
-          <Card.Img src={festival.thumbnail_url} style={{ height: '100%', overflowClipMargin: 'content-box', overflow: 'hidden', objectFit: 'cover' }} />
-          <Card.Body className="festival_visual_body" style={{ position: 'absolute', top: '50%', bottom: 0, left: 0, right: 0, color: 'white', textShadow: '1px 1px 0px rgba(0, 0, 0, 0.6)', borderRadius: '0.5rem', background: 'linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0))' }}>
-            <Card.Title className="festival_visual_title" style={{ fontWeight: 'bold' }}>{festival.name}</Card.Title>
-            <Card.Text style={{ fontWeight: 'bold' }}>
-              {formatDate(festival.start_date)} ~ {formatDate(festival.end_date)}<br />
+      <li
+        className="festival_visual_item"
+        style={{ display: "inline-block", margin: "1rem" }}
+      >
+        <Card
+          as={Link}
+          to={`/festivals/${festival._id}`}
+          style={{
+            width: "15rem",
+            height: "30rem",
+            border: "none",
+            position: "relative",
+            textDecorationLine: "none",
+          }}
+        >
+          <Card.Img
+            src={festival.thumbnail_url}
+            style={{
+              height: "100%",
+              overflowClipMargin: "content-box",
+              overflow: "hidden",
+              objectFit: "cover",
+            }}
+          />
+          <Card.Body
+            className="festival_visual_body"
+            style={{
+              position: "absolute",
+              top: "50%",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              color: "white",
+              textShadow: "1px 1px 0px rgba(0, 0, 0, 0.6)",
+              borderRadius: "0.5rem",
+              background:
+                "linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0))",
+            }}
+          >
+            <Card.Title
+              className="festival_visual_title"
+              style={{ fontWeight: "bold" }}
+            >
+              {festival.name}
+            </Card.Title>
+            <Card.Text style={{ fontWeight: "bold" }}>
+              {formatDate(festival.start_date)} ~{" "}
+              {formatDate(festival.end_date)}
+              <br />
               {festival.region}
             </Card.Text>
           </Card.Body>
@@ -41,8 +84,8 @@ function FestivalVisualList(props) {
 
   return (
     <div className="festival_visual_list_container">
-      <ul className="festival_visual_list" style={{ paddingLeft: '0' }}>
-        {featuredFestivals.map(festival => (
+      <ul className="festival_visual_list" style={{ paddingLeft: "0" }}>
+        {featuredFestivals.map((festival) => (
           <FestivalVisual key={festival._id} {...festival} />
         ))}
       </ul>

--- a/frontend/src/components/scrollTo.jsx
+++ b/frontend/src/components/scrollTo.jsx
@@ -1,6 +1,6 @@
 export function scrollTo(ref) {
   ref.current?.scrollIntoView({
-    behavior: "smooth",
+    behavior: "auto",
     block: "start",
   });
 }

--- a/frontend/src/components/scrollTo.jsx
+++ b/frontend/src/components/scrollTo.jsx
@@ -1,0 +1,6 @@
+export function scrollTo(ref) {
+  ref.current?.scrollIntoView({
+    behavior: "smooth",
+    block: "start",
+  });
+}

--- a/frontend/src/components/scrollTo.jsx
+++ b/frontend/src/components/scrollTo.jsx
@@ -1,6 +1,6 @@
 export function scrollTo(ref) {
   ref.current?.scrollIntoView({
-    behavior: "auto",
+    behavior: "smooth",
     block: "start",
   });
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,7 +8,6 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,8 @@
+@import url("https://cdn.jsdelivr.net/gh/moonspam/NanumBarunGothic@latest/nanumbarungothicsubset.css");
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --bs-body-font-family: "NanumBarunGothic", system-ui, Avenir, Helvetica, Arial,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
@@ -12,78 +14,4 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-html,
-body,
-#root {
-  height: 100%;
-  /* 루트 높이 확보 */
-  margin: 0;
-  /* 기본 마진 제거 */
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  min-width: 320px;
-  min-height: 100vh;
-
-  display: flex;
-  justify-content: center;
-  /* 가로 가운데 */
-  align-items: flex-start;
-  /* 위쪽 정렬 */
-  padding-top: 40px;
-  /* 원하는 만큼 내려줌 */
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-
-button:hover {
-  border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-
-  a:hover {
-    color: #747bff;
-  }
-
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,16 +2,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
-import App from "./App.jsx"; 
+import App from "./App.jsx";
 import "bootstrap/dist/css/bootstrap.min.css";
+import "./index.css";
 
 // APP 에서 Router 리턴
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-
       <App />
-
     </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/pages/CalendarPage.css
+++ b/frontend/src/pages/CalendarPage.css
@@ -9,13 +9,20 @@
 
 .calendar-header-card {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
   padding: 12px 16px;
   border-radius: 6px;
   background-color: #fff;
   border: 1px solid #e9ecef;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+@media (min-width: 768px) {
+  .calendar-header-card {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
 }
 
 .calendar-title {
@@ -47,11 +54,16 @@
 }
 
 .calendar-section {
+  margin: auto;
   border-radius: 6px;
   background-color: #fff;
   border: 1px solid #e9ecef;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   overflow: hidden;
+}
+
+.calendar-calendar-section {
+  max-width: 600px;
 }
 
 .festival-list-header {

--- a/frontend/src/pages/CalendarPage.jsx
+++ b/frontend/src/pages/CalendarPage.jsx
@@ -13,11 +13,20 @@ export default function CalendarPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [todayFestivals, setTodayFestivals] = useState([]);
   const festivalListRef = useRef(null);
+  const shouldScroll = useRef(false);
 
   // 현재 날짜의 축제 목록
   useEffect(() => {
     getDateFestivals(currentDate).then(setTodayFestivals);
   }, [currentDate]);
+
+  // 축제 목록이 변경되고 스크롤 플래그가 설정된 경우에만 스크롤
+  useEffect(() => {
+    if (shouldScroll.current && todayFestivals.length > 0) {
+      scrollTo(festivalListRef);
+      shouldScroll.current = false;
+    }
+  }, [todayFestivals]);
 
   // 연도, 월, 일 정보 추출
   const year = currentDate.getFullYear();
@@ -58,8 +67,8 @@ export default function CalendarPage() {
   const changeDay = (day) => {
     const newDate = new Date(currentDate);
     newDate.setDate(day);
+    shouldScroll.current = true; // 날짜 클릭 시에만 스크롤 플래그 설정
     setCurrentDate(newDate);
-    scrollTo(festivalListRef);
   };
 
   // 달력에 표시한 날짜
@@ -153,11 +162,7 @@ export default function CalendarPage() {
                 </h4>
               </div>
               <div className="festival-list-content">
-                {todayFestivals.length != 0 ? (
-                  <FestivalCardList festivals={todayFestivals} />
-                ) : (
-                  "축제가 없습니다."
-                )}
+                <FestivalCardList festivals={todayFestivals} />
               </div>
             </div>
           </Col>

--- a/frontend/src/pages/CalendarPage.jsx
+++ b/frontend/src/pages/CalendarPage.jsx
@@ -132,7 +132,6 @@ export default function CalendarPage() {
           <Col>
             <div
               className="calendar-section calendar-calendar-section"
-              // ref={festivalListRef}
             >
               <Calendar
                 dates={getCalendarDates()}

--- a/frontend/src/pages/CalendarPage.jsx
+++ b/frontend/src/pages/CalendarPage.jsx
@@ -1,15 +1,10 @@
 import React from "react";
 import Calendar from "../components/Calendar";
-import { useState, useEffect } from "react";
-import {
-  Container,
-  Row,
-  Col,
-  Button,
-  ButtonGroup,
-} from "react-bootstrap";
+import { useState, useEffect, useRef } from "react";
+import { Container, Row, Col, Button, ButtonGroup } from "react-bootstrap";
 import Badge from "react-bootstrap/Badge";
-import FestivalVisualList from "../components/FestivalVisualList";
+import FestivalCardList from "../components/FestivalCardList";
+import { scrollTo } from "../components/scrollTo";
 import { getDateFestivals } from "../api/api";
 import "./CalendarPage.css";
 
@@ -17,6 +12,7 @@ export default function CalendarPage() {
   // 현재 날짜를 state로 관리
   const [currentDate, setCurrentDate] = useState(new Date());
   const [todayFestivals, setTodayFestivals] = useState([]);
+  const festivalListRef = useRef(null);
 
   // 현재 날짜의 축제 목록
   useEffect(() => {
@@ -63,6 +59,7 @@ export default function CalendarPage() {
     const newDate = new Date(currentDate);
     newDate.setDate(day);
     setCurrentDate(newDate);
+    scrollTo(festivalListRef);
   };
 
   // 달력에 표시한 날짜
@@ -92,42 +89,42 @@ export default function CalendarPage() {
       <Container className="calendar-page-container">
         {/* Header Section */}
         <Row className="mb-4">
-          <Col>
-            <div className="calendar-header-card">
+          <div className="calendar-header-card">
+            <Col xs={12} md={8}>
               <div>
                 <h2 className="calendar-title">축제 달력</h2>
                 <p className="calendar-subtitle">
                   대한민국 전국 축제 정보를 한눈에 확인하세요
                 </p>
               </div>
+            </Col>
+            <Col
+              xs={12}
+              md={4}
+              className="d-flex justify-content-md-end justify-content-start mt-3 mt-md-0"
+            >
               <ButtonGroup className="calendar-nav">
-                <Button
-                  className="calendar-nav-button"
-                  onClick={toPrevMonth}
-                >
-                  ◀ 이전
+                <Button className="calendar-nav-button" onClick={toPrevMonth}>
+                  ◀
                 </Button>
-                <Button
-                  className="calendar-nav-button current"
-                  disabled
-                >
-                  {year}년 {month + 1}월
+                <Button className="calendar-nav-button current" disabled>
+                  {year}. {month + 1}
                 </Button>
-                <Button
-                  className="calendar-nav-button"
-                  onClick={toNextMonth}
-                >
-                  다음 ▶
+                <Button className="calendar-nav-button" onClick={toNextMonth}>
+                  ▶
                 </Button>
               </ButtonGroup>
-            </div>
-          </Col>
+            </Col>
+          </div>
         </Row>
 
         {/* Calendar Section */}
         <Row className="mb-4">
           <Col>
-            <div className="calendar-section">
+            <div
+              className="calendar-section calendar-calendar-section"
+              // ref={festivalListRef}
+            >
               <Calendar
                 dates={getCalendarDates()}
                 year={year}
@@ -142,9 +139,9 @@ export default function CalendarPage() {
         </Row>
 
         {/* Festival List Section */}
-        <Row>
+        <Row ref={festivalListRef}>
           <Col>
-            <div className="calendar-section">
+            <div className="calendar-section ">
               <div className="festival-list-header">
                 <h4 className="festival-list-title">
                   <span className="festival-list-indicator"></span>
@@ -156,7 +153,11 @@ export default function CalendarPage() {
                 </h4>
               </div>
               <div className="festival-list-content">
-                <FestivalVisualList festivals={todayFestivals} />
+                {todayFestivals.length != 0 ? (
+                  <FestivalCardList festivals={todayFestivals} />
+                ) : (
+                  "축제가 없습니다."
+                )}
               </div>
             </div>
           </Col>

--- a/frontend/src/pages/FestivalListPage.jsx
+++ b/frontend/src/pages/FestivalListPage.jsx
@@ -11,6 +11,7 @@ function FestivalListPage() {
 
   // 자동스크롤 용도
   const festivalCardListRef = useRef(null);
+  const shouldScroll = useRef(false);
 
   useEffect(() => {
     const fetchFestivals = async () => {
@@ -30,6 +31,13 @@ function FestivalListPage() {
     fetchFestivals();
   }, []);
 
+  useEffect(() => {
+    if (shouldScroll.current) {
+      scrollTo(festivalCardListRef);
+      shouldScroll.current = false;
+    }
+  }, [festivals]);
+
   return (
     <Container fluid="sm">
       <div
@@ -44,8 +52,8 @@ function FestivalListPage() {
         {/* <a href="/festivals/68a3165616876786b3a4b469">테스트용 : 상세페이지</a> */}
         <FestivalSearch
           onSearch={(data) => {
+            shouldScroll.current = true;
             setFestivals(data);
-            scrollTo(festivalCardListRef);
           }}
         />
         <FestivalVisualList

--- a/frontend/src/pages/FestivalListPage.jsx
+++ b/frontend/src/pages/FestivalListPage.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
-
+import React, { useEffect, useState, useRef } from "react";
+import { Container } from "react-bootstrap";
+import { scrollTo } from "../components/scrollTo";
 import FestivalSearch from "../components/FestivalSearch";
 import FestivalVisualList from "../components/FestivalVisualList";
 import FestivalCardList from "../components/FestivalCardList";
@@ -7,6 +8,9 @@ import FestivalCardList from "../components/FestivalCardList";
 function FestivalListPage() {
   const [festivals, setFestivals] = useState([]);
   const [mainFestivals, setMainFestivals] = useState([]);
+
+  // 자동스크롤 용도
+  const festivalCardListRef = useRef(null);
 
   useEffect(() => {
     const fetchFestivals = async () => {
@@ -27,12 +31,34 @@ function FestivalListPage() {
   }, []);
 
   return (
-     <div className="festival_list_page" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '1rem' }}>
-      {/* <a href="/festivals/68a3165616876786b3a4b469">테스트용 : 상세페이지</a> */}
-      <FestivalSearch onSearch={(data) => { setFestivals(data) }} />
-      <FestivalVisualList festivals={mainFestivals.slice(0, 3) /* 임시-나중에 추천 축제 3가지를 넣어줘야 함. */} />
-      <FestivalCardList festivals={festivals} />
-    </div>
+    <Container fluid="sm">
+      <div
+        className="festival_list_page"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          padding: "1rem",
+        }}
+      >
+        {/* <a href="/festivals/68a3165616876786b3a4b469">테스트용 : 상세페이지</a> */}
+        <FestivalSearch
+          onSearch={(data) => {
+            setFestivals(data);
+            scrollTo(festivalCardListRef);
+          }}
+        />
+        <FestivalVisualList
+          festivals={
+            mainFestivals.slice(
+              0,
+              3
+            ) /* 임시-나중에 추천 축제 3가지를 넣어줘야 함. */
+          }
+        />
+        <FestivalCardList festivals={festivals} ref={festivalCardListRef} />
+      </div>
+    </Container>
   );
 }
 


### PR DESCRIPTION
`CalendarPage.jsx`에서 날짜 선택 시 행사 목록으로 스크롤.
`FestivalListPage.jsx`에서 검색 씨 행사 목록으로 스크롤. 되게끔 구현했습니다

# `components/scrollTo.jsx`

```js
export function scrollTo(ref) {
  ref.current?.scrollIntoView({
    behavior: "auto",
    block: "start",
  });
}
```
- `ref` 위치까지 스크롤해주는 역할

# `pages/CalendarPage.jsx`

```js
// 축제 목록이 변경되고 스크롤 플래그가 설정된 경우에만 스크롤
  useEffect(() => {
    if (shouldScroll.current && todayFestivals.length > 0) {
      scrollTo(festivalListRef);
      shouldScroll.current = false;
    }
  }, [todayFestivals]);

// 생략

{/* Festival List Section */}
        <Row ref={festivalListRef}>
```
- `todayFestivals` state가 변경되면, `scrollTo` 실행되어 `festivalListRef`까지 이동
- 단 `shouldScroll` ref가 `true`인 경우만. (달을 바꾸거나, 맨 처음 새로고침하는 경우 `false`라 스크롤되지 않음)`

# `pages/FestivalListPage.jsx`
```js
// 축제 목록이 변경되고 스크롤 플래그가 설정된 경우에만 스크롤
  useEffect(() => {
    if (shouldScroll.current) {
      scrollTo(festivalCardListRef);
      shouldScroll.current = false;
    }
  }, [festivals]);
```
- 비슷하게 `festivals`  state가 변경되면, `scrollTo` 실행되어 `festivalCardListRef`까지 이동
- 단 `shouldScroll` ref가 `true`인 경우만 (맨 처음 새로고침하는 경우 `false`라 스크롤되지 않음)


